### PR TITLE
✨ feat: improve tournament calculator command

### DIFF
--- a/Discord/Commands/CalculateTournamentPoints.cs
+++ b/Discord/Commands/CalculateTournamentPoints.cs
@@ -5,6 +5,7 @@ using Discord.Util;
 using NetCord.Rest;
 using NetCord.Services.ApplicationCommands;
 
+using Shared.Schemas;
 using Shared.Schemas.Supervive;
 using Shared.Schemas.Supervive.Private;
 using Shared.Schemas.Supervive.Public;
@@ -55,12 +56,11 @@ namespace Discord.Commands {
 														await supervive.GetMatch(m.Split('-')[0], string.Join('-', m.Split('-').TakeLast(5))))
 											.ToArray());
 
-			Dictionary<string, int> placement         = tournament.CalculateTeamPoints(matches);
-			PublicMatchData[]       summedPlayerStats = tournament.SumPlayerStats(matches);
+			IReadOnlyDictionary<string, RosterResult> rosters = tournament.AggregateRosters(matches, minOverlap: 2);
 
 			await this.ModifyResponseAsync(m => {
-				m.Embeds = [tournamentHelper.BuildTournamentResultEmbed(placement, summedPlayerStats, topTeams)];
-				if (attachData) m.Attachments = [tournamentHelper.BuildTournamentResultCsv(summedPlayerStats)];
+				m.Embeds = [tournamentHelper.BuildTournamentResultEmbed(rosters.Values, topTeams)];
+				if (attachData) m.Attachments = [tournamentHelper.BuildTournamentResultCsv(rosters.Values)];
 			});
 		}
 	}

--- a/Discord/Services/TournamentHelperService.cs
+++ b/Discord/Services/TournamentHelperService.cs
@@ -8,7 +8,6 @@ using NetCord.Rest;
 
 using Shared.Schemas;
 using Shared.Schemas.Supervive.Public;
-using Shared.Services;
 
 namespace Discord.Services {
 	public interface ITournamentHelperService {
@@ -16,7 +15,7 @@ namespace Discord.Services {
 		public AttachmentProperties BuildTournamentResultCsv(IEnumerable<RosterResult>   rosters);
 	}
 
-	public class TournamentHelperService(ITournamentService tournamentService) :ITournamentHelperService {
+	public class TournamentHelperService :ITournamentHelperService {
 		public static void ConfigureService(IServiceCollection services) {
 			services.AddScoped<ITournamentHelperService, TournamentHelperService>();
 		}

--- a/Shared/Schemas/RosterResult.cs
+++ b/Shared/Schemas/RosterResult.cs
@@ -7,5 +7,5 @@ public record RosterResult {
 	public          HashSet<string>                     CanonicalMemberIds { get; } = [];
 	public          List<int>                           Placements         { get; } = [];
 	public          int                                 Points             { get; set; }
-	public          Dictionary<string, PublicMatchData> Players            { get; } = new();
+	public          Dictionary<string, PublicMatchData> Players            { get; } = [];
 }

--- a/Shared/Schemas/RosterResult.cs
+++ b/Shared/Schemas/RosterResult.cs
@@ -1,0 +1,11 @@
+﻿using Shared.Schemas.Supervive.Public;
+
+namespace Shared.Schemas;
+
+public record RosterResult {
+	public required string                              RosterId           { get; set; }
+	public          HashSet<string>                     CanonicalMemberIds { get; } = [];
+	public          List<int>                           Placements         { get; } = [];
+	public          int                                 Points             { get; set; }
+	public          Dictionary<string, PublicMatchData> Players            { get; } = new();
+}

--- a/Shared/Schemas/Supervive/Public/PublicPlayerStats.cs
+++ b/Shared/Schemas/Supervive/Public/PublicPlayerStats.cs
@@ -3,24 +3,24 @@
 namespace Shared.Schemas.Supervive.Public {
 	public record PublicPlayerStats {
 		[JsonPropertyName("Kills")]
-		public int Kills { get; init; }
+		public int Kills { get; set; }
 		
 		[JsonPropertyName("Deaths")]
-		public int Deaths { get; init; }
+		public int Deaths { get; set; }
 		
 		[JsonPropertyName("Assists")]
-		public int Assists { get; init; }
+		public int Assists { get; set; }
 		
 		[JsonPropertyName("HealingGiven")]
-		public double HealingGiven { get; init; }
+		public double HealingGiven { get; set; }
 		
 		[JsonPropertyName("HealingGivenSelf")]
-		public double HealingGivenSelf { get; init; }
+		public double HealingGivenSelf { get; set; }
 		
 		[JsonPropertyName("HeroEffectiveDamageDone")]
-		public double HeroEffectiveDamageDone { get; init; }
+		public double HeroEffectiveDamageDone { get; set; }
 		
 		[JsonPropertyName("HeroEffectiveDamageTaken")]
-		public double HeroEffectiveDamageTaken { get; init; }
+		public double HeroEffectiveDamageTaken { get; set; }
 	}
 }

--- a/Shared/Services/TournamentService.cs
+++ b/Shared/Services/TournamentService.cs
@@ -59,7 +59,7 @@ namespace Shared.Services {
 
 		public IReadOnlyDictionary<string, RosterResult> AggregateRosters(PublicMatchData[][] matchesData, int minOverlap = 2) {
 			List<RosterResult>               rosters = [];
-			Dictionary<string, RosterResult> byId    = new();
+			Dictionary<string, RosterResult> byId    = [];
 
 			foreach (PublicMatchData[] match in matchesData) {
 				foreach (IGrouping<int, PublicMatchData> teamGroup in match.GroupBy(p => p.TeamId)) {
@@ -99,7 +99,7 @@ namespace Shared.Services {
 			RosterResult? best      = null;
 			int           bestMatch = 0;
 
-			HashSet<string> current = new(memberIdsSorted);
+			HashSet<string> current = [..memberIdsSorted];
 
 			foreach (RosterResult roster in rosters) {
 				int overlap = roster.CanonicalMemberIds.Count(id => current.Contains(id));


### PR DESCRIPTION
- Implement dynamic roster grouping (>= 2 common players) across matches.
- Leaderboard shows per‑match placements and total points (e.g., “# 1: 1º, 5º, 2º, 1º, 1º - 162pts”).
- Sum stats per roster (only matches played for that roster); CSV updated accordingly.
- Add TournamentService.AggregateRosters; command now uses it; helper updated to build embed/CSV from roster results.
- Minor: fix roster key ordering in CalculateTeamPoints; per‑player score remains kills.